### PR TITLE
Update lvm.go

### DIFF
--- a/lvm.go
+++ b/lvm.go
@@ -39,7 +39,7 @@ func Volume(rs io.ReadSeeker) (*types.Volume, error) {
 	if err != nil {
 		return nil, xerrors.Errorf("failed to create physical volume header: %w", err)
 	}
-	var v *types.Volume
+	var v types.Volume
 	v.LabelHeader = vlh
 	v.Header = vh
 
@@ -51,7 +51,7 @@ func Volume(rs io.ReadSeeker) (*types.Volume, error) {
 		v.MetadataArea = append(v.MetadataArea, m)
 	}
 
-	return v, nil
+	return &v, nil
 }
 
 func NewPhysicalVolumeHeader(r io.Reader) (types.PhysicalVolumeHeader, error) {


### PR DESCRIPTION
fix

panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x4f901a]

goroutine 1 [running]:
github.com/masahiro331/go-lvm.Volume({0x55d8d8, 0xc00000e148})
        /root/go/pkg/mod/github.com/masahiro331/go-lvm@v0.0.0-20221225151933-a7705016276e/lvm.go:43 +0x23a